### PR TITLE
Add defintion for RE-K70-BYK800 (sold as Hykker X Range 2017)

### DIFF
--- a/src/part.rs
+++ b/src/part.rs
@@ -24,9 +24,18 @@ pub const PART_XINMENG_K916: Part = Part {
     product_id: 0x00a1,
 };
 
+pub const PART_RE_K70_BYK800: Part = Part {
+    flash_size: 28672, // 28672 until bootloader
+    bootloader_size: 4096,
+    page_size: 2048,
+    vendor_id: 0x258a,
+    product_id: 0x001a,
+};
+
 pub static PARTS: phf::Map<&'static str, Part> = phf_map! {
     "nuphy-air60" => PART_NUPHY_AIR60,
-    "xinmeng-k916" => PART_XINMENG_K916
+    "xinmeng-k916" => PART_XINMENG_K916,
+    "re-k70-byk800" => PART_RE_K70_BYK800,
 };
 
 impl Part {


### PR DESCRIPTION
**RE-K70-BYK800** is the only label (on PCB silkscreen) available on the device itself.
Other than it only has a company logo on outside, and rest comes from original cardboard packaging

![Silkcreen Label](https://github.com/carlossless/sinowealth-kb-tool/assets/270845/defef0b6-313f-41b5-a19a-670c9cf9279a)

[Repository with schematics for this board](https://github.com/swiftgeek/hykker-re)

After switching to bootloader, it re-enumerates with following descriptor:
```
Bus 001 Device 040: ID 0603:1020 Novatek Microelectronics Corp.
--
  | Device Descriptor:
  | bLength                18
  | bDescriptorType         1
  | bcdUSB               1.10
  | bDeviceClass            0
  | bDeviceSubClass         0
  | bDeviceProtocol         0
  | bMaxPacketSize0         8
  | idVendor           0x0603 Novatek Microelectronics Corp.
  | idProduct          0x1020
  | bcdDevice            1.00
  | iManufacturer           0
  | iProduct                0
  | iSerial                 0
  | bNumConfigurations      1
  | Configuration Descriptor:
  | bLength                 9
  | bDescriptorType         2
  | wTotalLength       0x001b
  | bNumInterfaces          1
  | bConfigurationValue     1
  | iConfiguration          0
  | bmAttributes         0x80
  | (Bus Powered)
  | MaxPower              100mA
  | Interface Descriptor:
  | bLength                 9
  | bDescriptorType         4
  | bInterfaceNumber        0
  | bAlternateSetting       0
  | bNumEndpoints           0
  | bInterfaceClass         3 Human Interface Device
  | bInterfaceSubClass      0
  | bInterfaceProtocol      0
  | iInterface              0
  | HID Device Descriptor:
  | bLength                 9
  | bDescriptorType        33
  | bcdHID               1.11
  | bCountryCode            0 Not supported
  | bNumDescriptors         1
  | bDescriptorType        34 Report
  | wDescriptorLength      92
  | Report Descriptor: (length is 92)
  | Item(Global): Usage Page, data= [ 0x01 ] 1
  | Generic Desktop Controls
  | Item(Local ): Usage, data= [ 0x06 ] 6
  | Keyboard
  | Item(Main  ): Collection, data= [ 0x01 ] 1
  | Application
  | Item(Global): Report ID, data= [ 0x01 ] 1
  | Item(Global): Usage Page, data= [ 0x07 ] 7
  | Keyboard
  | Item(Local ): Usage Minimum, data= [ 0xe0 ] 224
  | Control Left
  | Item(Local ): Usage Maximum, data= [ 0xe7 ] 231
  | GUI Right
  | Item(Global): Logical Minimum, data= [ 0x00 ] 0
  | Item(Global): Logical Maximum, data= [ 0x01 ] 1
  | Item(Global): Report Size, data= [ 0x01 ] 1
  | Item(Global): Report Count, data= [ 0x08 ] 8
  | Item(Main  ): Input, data= [ 0x02 ] 2
  | Data Variable Absolute No_Wrap Linear
  | Preferred_State No_Null_Position Non_Volatile Bitfield
  | Item(Global): Report Count, data= [ 0x06 ] 6
  | Item(Global): Report Size, data= [ 0x08 ] 8
  | Item(Global): Logical Minimum, data= [ 0x00 ] 0
  | Item(Global): Logical Maximum, data= [ 0xff 0x00 ] 255
  | Item(Global): Usage Page, data= [ 0x07 ] 7
  | Keyboard
  | Item(Local ): Usage Minimum, data= [ 0x00 ] 0
  | No Event
  | Item(Local ): Usage Maximum, data= [ 0xff 0x00 ] 255
  | (null)
  | Item(Main  ): Input, data= [ 0x00 ] 0
  | Data Array Absolute No_Wrap Linear
  | Preferred_State No_Null_Position Non_Volatile Bitfield
  | Item(Main  ): End Collection, data=none
  | Item(Global): Usage Page, data= [ 0x00 0xff ] 65280
  | (null)
  | Item(Local ): Usage, data= [ 0x01 ] 1
  | (null)
  | Item(Main  ): Collection, data= [ 0x01 ] 1
  | Application
  | Item(Global): Report ID, data= [ 0x05 ] 5
  | Item(Global): Logical Minimum, data= [ 0x00 ] 0
  | Item(Global): Logical Maximum, data= [ 0xff ] 255
  | Item(Local ): Usage Minimum, data= [ 0x01 ] 1
  | (null)
  | Item(Local ): Usage Maximum, data= [ 0x05 ] 5
  | (null)
  | Item(Global): Report Size, data= [ 0x08 ] 8
  | Item(Global): Report Count, data= [ 0x05 ] 5
  | Item(Main  ): Feature, data= [ 0x02 ] 2
  | Data Variable Absolute No_Wrap Linear
  | Preferred_State No_Null_Position Non_Volatile Bitfield
  | Item(Main  ): End Collection, data=none
  | Item(Global): Usage Page, data= [ 0x00 0xff ] 65280
  | (null)
  | Item(Local ): Usage, data= [ 0x01 ] 1
  | (null)
  | Item(Main  ): Collection, data= [ 0x01 ] 1
  | Application
  | Item(Global): Report ID, data= [ 0x06 ] 6
  | Item(Global): Logical Minimum, data= [ 0x00 ] 0
  | Item(Global): Logical Maximum, data= [ 0xff ] 255
  | Item(Local ): Usage Minimum, data= [ 0x01 ] 1
  | (null)
  | Item(Local ): Usage Maximum, data= [ 0x02 ] 2
  | (null)
  | Item(Global): Report Size, data= [ 0x08 ] 8
  | Item(Global): Report Count, data= [ 0x01 0x08 ] 2049
  | Item(Main  ): Feature, data= [ 0x02 ] 2
  | Data Variable Absolute No_Wrap Linear
  | Preferred_State No_Null_Position Non_Volatile Bitfield
  | Item(Main  ): End Collection, data=none
```

Original descriptor:
```
Bus 003 Device 060: ID 258a:001a  
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               1.10
  bDeviceClass            0 
  bDeviceSubClass         0 
  bDeviceProtocol         0 
  bMaxPacketSize0         8
  idVendor           0x258a 
  idProduct          0x001a 
  bcdDevice           30.90
  iManufacturer           1 Gaming KB 
  iProduct                2 Gaming KB 
  iSerial                 0 
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength           59
    bNumInterfaces          2
    bConfigurationValue     1
    iConfiguration          0 
    bmAttributes         0xa0
      (Bus Powered)
      Remote Wakeup
    MaxPower              300mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass         3 Human Interface Device
      bInterfaceSubClass      1 Boot Interface Subclass
      bInterfaceProtocol      1 Keyboard
      iInterface              0 
        HID Device Descriptor:
          bLength                 9
          bDescriptorType        33
          bcdHID               1.11
          bCountryCode            0 Not supported
          bNumDescriptors         1
          bDescriptorType        34 Report
          wDescriptorLength      65
         Report Descriptors: 
           ** UNAVAILABLE **
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0008  1x 8 bytes
        bInterval              10
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        1
      bAlternateSetting       0
      bNumEndpoints           1
      bInterfaceClass         3 Human Interface Device
      bInterfaceSubClass      1 Boot Interface Subclass
      bInterfaceProtocol      1 Keyboard
      iInterface              0 
        HID Device Descriptor:
          bLength                 9
          bDescriptorType        33
          bcdHID               1.11
          bCountryCode            0 Not supported
          bNumDescriptors         1
          bDescriptorType        34 Report
          wDescriptorLength     168
         Report Descriptors: 
           ** UNAVAILABLE **
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x82  EP 2 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0008  1x 8 bytes
        bInterval              10
Device Status:     0x0002
  (Bus Powered)
  Remote Wakeup Enabled
```

After writing modified image following was changed:
```
  iManufacturer           1 Swift Kbd                                          
  iProduct                2 Swift Kbd
```

---

Also accidentally issued erase alone by using wrong input file I guess, and it was still possible to recover by using correct input file. So losing entry point for reset vector and interrupts is not a problem for BYK801 ISP fw (as long as it doesn't lose power)