### PR TITLE
Air75 Read Support Confirmed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/carlossless/sinowealth-kb-tool"
 version = "0.0.3"
 edition = "2021"
 license = "MIT"
+rust-version = "1.65"
 
 [dependencies]
 clap = "4.1"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@ This is an experimental tool, so use it at your own risk.
 | Keyboard | ISP MD5 | MCU | Supported |
 | -------- | ------- | --- | --------- |
 | [NuPhy Air60](https://nuphy.com/products/air60) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A (labeled as BYK916) | ✅ |
+| [NuPhy Air75](https://nuphy.com/products/air75) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A (labeled as BYK916) | ✅‡ |
 | [NuPhy Halo65](https://nuphy.com/products/halo65) | 3e0ebd0c440af5236d7ff8872343f85d | ❓ | ✅ |
 | Hykker X Range 2017 (RE-K70-BYK800) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 (labeled as BYK801) | ✅ |
 | Xinmeng K916 | cfc8661da8c9d7e351b36c0a763426aa | SH68F90 | ✅ |
+
+‡ Reading tested, writing untested.
 
 ## Prerequisites
 

--- a/src/part.rs
+++ b/src/part.rs
@@ -35,6 +35,7 @@ pub const PART_RE_K70_BYK800: Part = Part {
 pub static PARTS: phf::Map<&'static str, Part> = phf_map! {
     "nuphy-air60" => PART_NUPHY_AIR60,
     "nuphy-halo65" => PART_NUPHY_AIR60, // same as nuphy-air60
+    "nuphy-air75" => PART_NUPHY_AIR60, // same as nuphy-air60
     "xinmeng-k916" => PART_XINMENG_K916,
     "re-k70-byk800" => PART_RE_K70_BYK800,
 };


### PR DESCRIPTION
* Confirmed following functionality with Air75:
  * Reading bootloader, hash matches other NuPhy products
  * Reading full-flash
* Added Air75 part (another Air60 reference)
* Added minimum Rust version (let-else not stabilized before Rust 1.65 w/ PR https://github.com/rust-lang/rust/pull/93628)