### PR TITLE
corrected ISP behaviour, documented commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -122,14 +122,8 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
 
 [[package]]
 name = "errno"
@@ -139,7 +133,7 @@ checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -184,14 +178,8 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "itoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "lazy_static"
@@ -230,15 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -332,25 +311,18 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.185"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
-
-[[package]]
 name = "simple_logger"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2230cd5c29b815c9b699fb610b49a5ed65588f3509d9f0108be3a885da629333"
+checksum = "da0ca6504625ee1aa5fda33913d2005eab98c7a42dd85f116ecce3ff54c9d3ef"
 dependencies = [
  "colored",
  "log",
- "time",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -412,36 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
-dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num_threads",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
-
-[[package]]
-name = "time-macros"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733d258752e9303d392b94b75230d07b0b9c489350c69b851fc6c065fde3e8f9"
-dependencies = [
- "time-core",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,21 +419,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -505,20 +432,14 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -528,21 +449,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -552,21 +461,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -576,21 +473,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ version = "0.4"
 features = ["max_level_debug", "release_max_level_info"]
 
 [dependencies.simple_logger]
-version = "4.1"
+version = "4.3"
+default-features = false
 features = ["stderr", "colors"]
 
 [dependencies.phf]

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Read [here](https://github.com/carlossless/sinowealth-kb-tool/issues/19) for ISP
 
 ### Reading
 
-⚠️ Reading is not entirely an idempotent operation. A read operation can change values in the `0xeffb - 0xeffd` region.
+⚠️ Reading is not entirely an idempotent operation. A read operation will insert an LJMP opcode at `0xeffb` if it's not already present.
 
-⚠️ The ISP bootloader will blank out bytes in the `0xeffb - 0xeffd` region, therefore the produced dump might not reflect the actual state in ROM.
+⚠️ The ISP bootloader will move the LJMP from `0xeffb` to `0x0000`, therefore the produced dump will not fully reflect the actual state in ROM.
 
 ```sh
 # reads firmware excluding isp bootloader 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ This is an experimental tool, so use it at your own risk.
 
 ## Usage
 
-Read [here](https://github.com/carlossless/sinowealth-kb-tool/issues/19) for ISP quirks.
-
 ### Reading
 
 ⚠️ A read operation will set an LJMP (0x02) opcode at address `0xeffb` if it's not already present there.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Read [here](https://github.com/carlossless/sinowealth-kb-tool/issues/19) for ISP
 
 ### Reading
 
-⚠️ Reading is not entirely an idempotent operation. A read operation will insert an LJMP opcode at `0xeffb` if it's not already present.
+⚠️ A read operation will set an LJMP opcode at `0xeffb` if it's not already present there.
 
-⚠️ The ISP bootloader will move the LJMP from `0xeffb` to `0x0000`, therefore the produced dump will not fully reflect the actual state in ROM.
+⚠️ When reading, the ISP bootloader redirects values in `0x0001-0x0002` to `0xeffc-0xeffd`. Knowing this, the tool attempts to fix up the read payload and place the values in the same places where they actually reside in flash.
 
 ```sh
 # reads firmware excluding isp bootloader 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This is an experimental tool, so use it at your own risk.
 
 ### Reading
 
-⚠️ A read operation will set an LJMP (0x02) opcode at address `0xeffb` if it's not already present there.
+⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there.
 
-⚠️ When reading, the ISP bootloader redirects values in `0x0001-0x0002` to `0xeffc-0xeffd`. The produced payload will be different from how memory is stored in flash.
+⚠️ When reading, the ISP bootloader redirects values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. The produced payload will be different from how memory is stored in flash.
 
 ```sh
 # reads firmware excluding isp bootloader 
@@ -38,7 +38,7 @@ sinowealth-kb-tool read \
 
 ### Writing
 
-⚠️ Same as the read operation, the ISP bootloader will write values meant for addresses `0x0001-0x0002` to `0xeffc-0xeffd`. 
+⚠️ Same as the read operation, the ISP bootloader will write values meant for addresses `0x0001-0x0002` to `<firmware_size-4> - <firmware_size-3>`. 
 
 ```sh
 # overwrites firmware (does not touch the bootloader section)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is an experimental tool, so use it at your own risk.
 
 ### Reading
 
-⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there.
+⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there. This essentially enables the firmware by causing the bootloader to jump to the specified addresses right after the device is turned on. This should not cause issues for most devices.
 
 ⚠️ When reading, the ISP bootloader redirects values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. The produced payload will be different from how memory is stored in flash.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This is an experimental tool, so use it at your own risk.
 
 ### Reading
 
-⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there. This essentially enables the firmware by causing the bootloader to jump to the specified addresses right after the device is turned on. This should not cause issues for most devices.
+⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there. This essentially enables the firmware by causing the bootloader to jump to the specified addresses right after the device is turned on, though, this should not cause issues on most devices.
 
-⚠️ When reading, the ISP bootloader redirects values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. The produced payload will be different from how memory is stored in flash.
+⚠️ Durring reading the ISP bootloader will redirect values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. Because of this, the produced payload will be different from how memory is actually laid out in the mcu flash.
 
 ```sh
 # reads firmware excluding isp bootloader 
@@ -38,7 +38,7 @@ sinowealth-kb-tool read \
 
 ### Writing
 
-⚠️ Same as the read operation, the ISP bootloader will write values meant for addresses `0x0001-0x0002` to `<firmware_size-4> - <firmware_size-3>`. 
+⚠️ Same as the [read](#reading) operation, the ISP bootloader will write values meant for addresses `0x0001-0x0002` to `<firmware_size-4> - <firmware_size-3>`. 
 
 ```sh
 # overwrites firmware (does not touch the bootloader section)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This is an experimental tool, so use it at your own risk.
 
 ### Reading
 
-⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there. This essentially enables the firmware by causing the bootloader to jump to the specified addresses right after the device is turned on, though, this should not cause issues on most devices.
+⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there. When this opcode is set, the bootloader considers the main firmware enabled and jumps to it when the device is powered on. This opcode should already be set on most devices and therefore the read operation **should** not cause any issues.
 
-⚠️ Durring reading the ISP bootloader will redirect values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. Because of this, the produced payload will be different from how memory is actually laid out in the mcu flash.
+⚠️ Durring reading the ISP bootloader will redirect values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. Because of this, the produced payload will be different from how memory is actually laid out in the MCU flash.
 
 ```sh
 # reads firmware excluding isp bootloader 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an experimental tool, so use it at your own risk.
 
 ⚠️ A read operation will set an LJMP (0x02) opcode at address `<firmware_size-5>` if it's not already present there. When this opcode is set, the bootloader considers the main firmware enabled and jumps to it when the device is powered on. This opcode should already be set on most devices and therefore the read operation **should** not cause any issues.
 
-⚠️ Durring reading the ISP bootloader will redirect values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. Because of this, the produced payload will be different from how memory is actually laid out in the MCU flash.
+⚠️ During reading the ISP bootloader will redirect values in `0x0001 - 0x0002` to `<firmware_size-4> - <firmware_size-3>`. Because of this, the produced payload will be different from how memory is actually laid out in the MCU flash.
 
 ```sh
 # reads firmware excluding isp bootloader 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Read [here](https://github.com/carlossless/sinowealth-kb-tool/issues/19) for ISP
 
 ### Reading
 
-⚠️ A read operation will set an LJMP opcode at `0xeffb` if it's not already present there.
+⚠️ A read operation will set an LJMP (0x02) opcode at address `0xeffb` if it's not already present there.
 
-⚠️ When reading, the ISP bootloader redirects values in `0x0001-0x0002` to `0xeffc-0xeffd`. Knowing this, the tool attempts to fix up the read payload and place the values in the same places where they actually reside in flash.
+⚠️ When reading, the ISP bootloader redirects values in `0x0001-0x0002` to `0xeffc-0xeffd`. The produced payload will be different from how memory is stored in flash.
 
 ```sh
 # reads firmware excluding isp bootloader 
@@ -39,6 +39,8 @@ sinowealth-kb-tool read \
 ```
 
 ### Writing
+
+⚠️ Same as the read operation, the ISP bootloader will write values meant for addresses `0x0001-0x0002` to `0xeffc-0xeffd`. 
 
 ```sh
 # overwrites firmware (does not touch the bootloader section)

--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ Make sure your user is part of the `plugdev` group.
 
 ## Acknowledgments
 
-Thanks to @gashtaan for analyzing and explaining the inner workings of the ISP bootloaders. Without his help, this tool wouldn't be here!
+Thanks to [@gashtaan](https://github.com/gashtaan) for analyzing and explaining the inner workings of the ISP bootloaders. Without his help, this tool wouldn't be here!

--- a/README.md
+++ b/README.md
@@ -85,5 +85,4 @@ Make sure your user is part of the `plugdev` group.
 
 ## Acknowledgments
 
-* https://github.com/gashtaan/sinowealth-8051-dumper
-* https://github.com/ayufan-rock64/pinebook-pro-keyboard-updater
+Thanks to @gashtaan for analyzing and explaining the inner workings of the ISP bootloaders. Without his help, this tool wouldn't be here!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ sinowealth-kb-tool read -p nuphy-air60 --full full.hex
 
 # custom device
 sinowealth-kb-tool read \
-    --flash_size 61440 \
+    --firmware_size 61440 \
     --bootloader_size 4096 \
     --page_size 2048 \
     --vendor_id 0x05ac \
@@ -46,7 +46,7 @@ sinowealth-kb-tool write -p nuphy-air60 foobar.hex
 
 # custom device
 sinowealth-kb-tool write \
-    --flash_size 61440 \
+    --firmware_size 61440 \
     --bootloader_size 4096 \
     --page_size 2048 \
     --vendor_id 0x05ac \

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -305,7 +305,6 @@ impl ISPDevice {
 
         let page_size = self.part.page_size;
         for i in 0..self.part.num_pages() {
-            // skip the last page
             debug!("Writing page {} @ offset {:#06x}", i, i * page_size);
             self.write_page(&buffer[(i * page_size)..((i + 1) * page_size)])?;
         }

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -382,7 +382,7 @@ impl ISPDevice {
     fn enable_firmware(&self) -> Result<(), ISPError> {
         info!("Enabling firmware...");
         let cmd: [u8; COMMAND_LENGTH] =
-            [REPORT_ID_CMD, CMD_ENABLE_FIRMWARE, 0x00, 0x00, 0x00, 0x00];
+            [REPORT_ID_CMD, CMD_ENABLE_FIRMWARE, 0, 0, 0, 0];
 
         self.request_device.send_feature_report(&cmd)?;
         Ok(())

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -256,13 +256,13 @@ impl ISPDevice {
     }
 
     pub fn write_cycle(&self, firmware: &mut Vec<u8>) -> Result<(), ISPError> {
-        // ensure that addr <firmware_len-4> has the same reset vector
+        // ensure that addr <firmware_size-4> has the same reset vector
         firmware.copy_within(1..3, self.part.firmware_size - 4);
 
         self.erase()?;
         self.write(0, firmware)?;
 
-        // cleanup changes made at <firmware_len-4>
+        // cleanup changes made at <firmware_size-4>
         firmware[self.part.firmware_size - 4..self.part.firmware_size - 2].fill(0);
 
         info!("Verifying...");
@@ -360,7 +360,7 @@ impl ISPDevice {
     ///
     /// Note: The first 3 bytes at address 0x0000 (first-page) are skipped. Instead the second and
     /// third bytes (firmware's reset vector LJMP destination address) are written to address
-    /// <firmware_len-4> and will later be part of the LJMP instruction after the firmware is
+    /// <firmware_size-4> and will later be part of the LJMP instruction after the firmware is
     /// enabled (`enable_firmware`). This only works once after an erase operation.
     fn write_page(&self, buf: &[u8]) -> Result<(), ISPError> {
         let length = buf.len() + 2;
@@ -374,7 +374,7 @@ impl ISPDevice {
         Ok(())
     }
 
-    /// Sets a LJMP (0x02) opcode at <firmware_len-5>.
+    /// Sets a LJMP (0x02) opcode at <firmware_size-5>.
     /// This enables the main firmware by making the bootloader jump to it on reset.
     ///
     /// Side-effect: enables reading the firmware without erasing flash first.

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -256,13 +256,13 @@ impl ISPDevice {
     }
 
     pub fn write_cycle(&self, firmware: &mut Vec<u8>) -> Result<(), ISPError> {
-        // ensure that addr <firmware_size-4> has the same reset vector
+        // ensure that the address at <firmware_size-4> is the same as the reset vector
         firmware.copy_within(1..3, self.part.firmware_size - 4);
 
         self.erase()?;
         self.write(0, firmware)?;
 
-        // cleanup changes made at <firmware_size-4>
+        // cleanup the address at <firmware_size-4>
         firmware[self.part.firmware_size - 4..self.part.firmware_size - 2].fill(0);
 
         info!("Verifying...");

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -269,7 +269,7 @@ impl ISPDevice {
             self.fixup_firmware(&mut firmware);
         }
 
-        return Ok(firmware)
+        return Ok(firmware);
     }
 
     pub fn write_cycle(&self, firmware: &mut Vec<u8>) -> Result<(), ISPError> {

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -38,12 +38,6 @@ pub struct ISPDevice {
 }
 
 #[derive(Debug, Error)]
-pub enum FirmwareError {
-    #[error("Last firmware page is not blank")]
-    LastPageNotBlank,
-}
-
-#[derive(Debug, Error)]
 pub enum ISPError {
     #[error("Duplicate devices found")]
     DuplicateDevices(String, String),
@@ -53,8 +47,6 @@ pub enum ISPError {
     HidError(#[from] HidError),
     #[error(transparent)]
     VerificationError(#[from] VerificationError),
-    #[error(transparent)]
-    FirmwareError(#[from] FirmwareError),
 }
 
 #[derive(Debug, Clone)]
@@ -364,7 +356,10 @@ impl ISPDevice {
 
     /// Writes one page to flash
     ///
-    /// Note: The first 3 bytes at address 0x0000 (first-page) are skipped. Instead the second and third bytes (firmware's reset vector LJMP destination address) are written to address <firmware_len-4> and will later be part of the LJMP instruction after the firmware is enabled (`enable_firmware`). This only works once after an erase operation.
+    /// Note: The first 3 bytes at address 0x0000 (first-page) are skipped. Instead the second and
+    /// third bytes (firmware's reset vector LJMP destination address) are written to address
+    /// <firmware_len-4> and will later be part of the LJMP instruction after the firmware is
+    /// enabled (`enable_firmware`). This only works once after an erase operation.
     fn write_page(&self, buf: &[u8]) -> Result<(), ISPError> {
         let length = buf.len() + 2;
         let mut xfer_buf: Vec<u8> = vec![0; length];
@@ -380,7 +375,8 @@ impl ISPDevice {
     /// Sets a LJMP (0x02) opcode at <firmware_len-5>.
     /// This enables the main firmware by making the bootloader jump to it on reset.
     ///
-    /// Side-effect: enables reading the firmware without erasing flash first. Credits to @gashtaan for finding this out.
+    /// Side-effect: enables reading the firmware without erasing flash first.
+    /// Credits to @gashtaan for finding this out.
     fn enable_firmware(&self) -> Result<(), ISPError> {
         info!("Enabling firmware...");
         let cmd: [u8; COMMAND_LENGTH] =
@@ -390,7 +386,8 @@ impl ISPDevice {
         Ok(())
     }
 
-    /// Erases everything in flash, except the ISP bootloader section itself and initializes the reset vector to jump to ISP.
+    /// Erases everything in flash, except the ISP bootloader section itself and initializes the
+    /// reset vector to jump to ISP.
     fn erase(&self) -> Result<(), ISPError> {
         info!("Erasing...");
         let cmd: [u8; COMMAND_LENGTH] = [REPORT_ID_CMD, CMD_ERASE, 0, 0, 0, 0];

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -265,9 +265,10 @@ impl ISPDevice {
         // cleanup the address at <firmware_size-4>
         firmware[self.part.firmware_size - 4..self.part.firmware_size - 2].fill(0);
 
+        let read_back = self.read(0, self.part.firmware_size)?;
+
         info!("Verifying...");
-        let written = self.read(0, self.part.firmware_size)?;
-        util::verify(firmware, &written).map_err(ISPError::from)?;
+        util::verify(firmware, &read_back).map_err(ISPError::from)?;
 
         self.enable_firmware()?;
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,10 +111,10 @@ fn err_main() -> Result<(), CLIError> {
             let mut file_buf = Vec::new();
             file.read_to_end(&mut file_buf).map_err(CLIError::from)?;
             let file_str = String::from_utf8_lossy(&file_buf[..]);
-            let mut firmware = from_ihex(&file_str, part.flash_size).map_err(CLIError::from)?;
+            let mut firmware = from_ihex(&file_str, part.firmware_size).map_err(CLIError::from)?;
 
-            if firmware.len() < part.flash_size {
-                firmware.resize(part.flash_size, 0);
+            if firmware.len() < part.firmware_size {
+                firmware.resize(part.firmware_size, 0);
             }
 
             let isp = ISPDevice::new(part).map_err(CLIError::from)?;
@@ -135,7 +135,7 @@ impl PartCommand for Command {
             arg!(-p --part <PART>)
                 .value_parser(Part::available_parts())
                 .required_unless_present_all([
-                    "flash_size",
+                    "firmware_size",
                     "bootloader_size",
                     "page_size",
                     "vendor_id",
@@ -143,7 +143,7 @@ impl PartCommand for Command {
                 ]),
         )
         .arg(
-            arg!(--flash_size <SIZE>)
+            arg!(--firmware_size <SIZE>)
                 .required_unless_present("part")
                 .value_parser(clap::value_parser!(usize)),
         )
@@ -178,14 +178,14 @@ fn get_part_from_matches(sub_matches: &ArgMatches) -> Part {
         _ => Part::default(),
     };
 
-    let flash_size = sub_matches.get_one::<usize>("flash_size");
+    let firmware_size = sub_matches.get_one::<usize>("firmware_size");
     let bootloader_size = sub_matches.get_one::<usize>("bootloader_size");
     let page_size = sub_matches.get_one::<usize>("page_size");
     let vendor_id = sub_matches.get_one::<u16>("vendor_id");
     let product_id = sub_matches.get_one::<u16>("product_id");
 
-    if let Some(flash_size) = flash_size {
-        part.flash_size = *flash_size;
+    if let Some(firmware_size) = firmware_size {
+        part.firmware_size = *firmware_size;
     }
     if let Some(bootloader_size) = bootloader_size {
         part.bootloader_size = *bootloader_size;

--- a/src/part.rs
+++ b/src/part.rs
@@ -2,7 +2,7 @@ use phf::{phf_map, Map};
 
 #[derive(Default, Clone, Copy)]
 pub struct Part {
-    pub flash_size: usize,
+    pub firmware_size: usize,
     pub bootloader_size: usize,
     pub page_size: usize,
     pub vendor_id: u16,
@@ -10,7 +10,7 @@ pub struct Part {
 }
 
 pub const PART_NUPHY_AIR60: Part = Part {
-    flash_size: 61440, // 61440 until bootloader
+    firmware_size: 61440, // 61440 until bootloader
     bootloader_size: 4096,
     page_size: 2048,
     vendor_id: 0x05ac,
@@ -18,7 +18,7 @@ pub const PART_NUPHY_AIR60: Part = Part {
 };
 
 pub const PART_XINMENG_K916: Part = Part {
-    flash_size: 61440, // 61440 until bootloader
+    firmware_size: 61440, // 61440 until bootloader
     bootloader_size: 4096,
     page_size: 2048,
     vendor_id: 0x258a,
@@ -26,7 +26,7 @@ pub const PART_XINMENG_K916: Part = Part {
 };
 
 pub const PART_RE_K70_BYK800: Part = Part {
-    flash_size: 28672, // 28672 until bootloader
+    firmware_size: 28672, // 28672 until bootloader
     bootloader_size: 4096,
     page_size: 2048,
     vendor_id: 0x258a,
@@ -34,7 +34,7 @@ pub const PART_RE_K70_BYK800: Part = Part {
 };
 
 pub const PART_TERPORT_TR95: Part = Part {
-    flash_size: 61440, // 61440 until bootloader
+    firmware_size: 61440, // 61440 until bootloader
     bootloader_size: 4096,
     page_size: 2048,
     vendor_id: 0x258a,
@@ -42,7 +42,7 @@ pub const PART_TERPORT_TR95: Part = Part {
 };
 
 pub const PART_REDRAGON_FIZZ_K617: Part = Part {
-    flash_size: 61440, // 61440 until bootloader
+    firmware_size: 61440, // 61440 until bootloader
     bootloader_size: 4096,
     page_size: 2048,
     vendor_id: 0x258a,
@@ -66,7 +66,7 @@ impl Part {
     }
 
     pub fn num_pages(&self) -> usize {
-        self.flash_size / self.page_size
+        self.firmware_size / self.page_size
     }
 }
 

--- a/tools/functional-test.sh
+++ b/tools/functional-test.sh
@@ -57,7 +57,7 @@ reboot_device
 
 echo "Custom read..."
 $TOOL read \
-    --flash_size 61440 \
+    --firmware_size 61440 \
     --bootloader_size 4096 \
     --page_size 2048 \
     --vendor_id 0x05ac \


### PR DESCRIPTION
Changes here clean up all of the various ISP commands, remove the unused and not needed command arguments, remove unneeded firmware fixups (pre-read and pre-write), and document ISP behavior. 

Thanks to @gashtaan for providing details from his analysis of the bootloader code!

This also renames the `--flash_size` arg to `--firmware_size`.