### PR TITLE
device: redragon-k614-anivia

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ sinowealth-kb-tool write \
 | [NuPhy Halo65](https://nuphy.com/products/halo65) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ❓ |
 | Terport TR95 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ❓ |
 | [Redragon K617 FIZZ 60%](https://www.redragonzone.com/collections/keyboard/products/redragon-k617-fizz-60-wired-rgb-gaming-keyboard-61-keys-compact-mechanical-keyboard) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ❓ |
+| [Redragon K614 Anivia 60%](https://www.redragonzone.com/products/redragon-k614-anivia-60-ultra-thin-wired-mechanical-keyboard) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
 | Xinmeng K916 | cfc8661da8c9d7e351b36c0a763426aa | SH68F90 | ❓ | ✅ | ✅ |
 | Hykker X Range 2017 (RE-K70-BYK800) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 | BYK801 | ✅ | ❓ |
 

--- a/src/part.rs
+++ b/src/part.rs
@@ -49,6 +49,14 @@ pub const PART_REDRAGON_FIZZ_K617: Part = Part {
     product_id: 0x0049,
 };
 
+pub const PART_REDRAGON_ANIVIA_K614: Part = Part {
+    firmware_size: 61440, // 61440 until bootloader
+    bootloader_size: 4096,
+    page_size: 2048,
+    vendor_id: 0x258a,
+    product_id: 0x0049,
+};
+
 pub static PARTS: Map<&'static str, Part> = phf_map! {
     "nuphy-air60" => PART_NUPHY_AIR60,
     "nuphy-air75" => PART_NUPHY_AIR60, // same as nuphy-air60
@@ -57,7 +65,8 @@ pub static PARTS: Map<&'static str, Part> = phf_map! {
     "xinmeng-k916" => PART_XINMENG_K916,
     "re-k70-byk800" => PART_RE_K70_BYK800,
     "terport-tr95" => PART_TERPORT_TR95,
-    "redragon-k6170-fizz" => PART_REDRAGON_FIZZ_K617
+    "redragon-k6170-fizz" => PART_REDRAGON_FIZZ_K617,
+    "redragon-k614-anivia" => PART_REDRAGON_ANIVIA_K614
 };
 
 impl Part {


### PR DESCRIPTION
Support for [Redragon K614 Anivia](https://www.redragonzone.com/products/redragon-k614-anivia-60-ultra-thin-wired-mechanical-keyboard) keyboard.
Writing tested by flashing SMK firmware.