### PR TITLE
setting & using a specific interface number

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ sinowealth-kb-tool read \
     --firmware_size 61440 \
     --bootloader_size 4096 \ # optional
     --page_size 2048 \ # optional
+    --isp_iface_num 1 \ # optional
     --isp_usage_page 0xff00 \ # optional
     --isp_usage 0x0001 \ # optional
     --isp_index 0 \ # optional
@@ -54,6 +55,7 @@ sinowealth-kb-tool write \
     --firmware_size 61440 \
     --bootloader_size 4096 \ # optional
     --page_size 2048 \ # optional
+    --isp_iface_num 1 \ # optional
     --isp_usage_page 0xff00 \ # optional
     --isp_usage 0x0001 \ # optional
     --isp_index 0 \ # optional

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -93,11 +93,13 @@ impl ISPDevice {
                 #[cfg(not(target_os = "linux"))]
                 return d.vendor_id() == GAMING_KB_VENDOR_ID
                     && d.product_id() == GAMING_KB_PRODUCT_ID
+                    && d.interface_number() == 0
                     && d.usage_page() == HID_ISP_USAGE_PAGE
                     && d.usage() == HID_ISP_USAGE;
                 #[cfg(target_os = "linux")]
                 return d.vendor_id() == GAMING_KB_VENDOR_ID
-                    && d.product_id() == GAMING_KB_PRODUCT_ID;
+                    && d.product_id() == GAMING_KB_PRODUCT_ID
+                    && d.interface_number() == 0;
             })
             .collect();
 
@@ -160,10 +162,13 @@ impl ISPDevice {
                 #[cfg(not(target_os = "linux"))]
                 return d.vendor_id() == part.vendor_id
                     && d.product_id() == part.product_id
+                    && d.interface_number() == part.isp_iface_num as i32
                     && d.usage_page() == part.isp_usage_page
                     && d.usage() == part.isp_usage;
                 #[cfg(target_os = "linux")]
-                return d.vendor_id() == part.vendor_id && d.product_id() == part.product_id;
+                return d.vendor_id() == part.vendor_id
+                    && d.product_id() == part.product_id
+                    && d.interface_number() == part.isp_iface_num as i32;
             })
             .enumerate()
             .find_map(|(_i, d)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,6 +153,7 @@ impl PartCommand for Command {
         )
         .arg(arg!(--bootloader_size <SIZE>).value_parser(maybe_hex::<usize>))
         .arg(arg!(--page_size <SIZE>).value_parser(maybe_hex::<usize>))
+        .arg(arg!(--isp_iface_num <NUM>).value_parser(maybe_hex::<u8>))
         .arg(arg!(--isp_usage_page <PID>).value_parser(maybe_hex::<u16>))
         .arg(arg!(--isp_usage <PID>).value_parser(maybe_hex::<u16>))
         .arg(arg!(--isp_index <PID>).value_parser(maybe_hex::<usize>))
@@ -172,6 +173,7 @@ fn get_part_from_matches(sub_matches: &ArgMatches) -> Part {
     let page_size = sub_matches.get_one::<usize>("page_size");
     let vendor_id = sub_matches.get_one::<u16>("vendor_id");
     let product_id = sub_matches.get_one::<u16>("product_id");
+    let isp_iface_num = sub_matches.get_one::<u8>("isp_iface_num");
     let isp_usage_page = sub_matches.get_one::<u16>("isp_usage_page");
     let isp_usage = sub_matches.get_one::<u16>("isp_usage");
     let isp_index = sub_matches.get_one::<usize>("isp_index");
@@ -190,6 +192,9 @@ fn get_part_from_matches(sub_matches: &ArgMatches) -> Part {
     }
     if let Some(page_size) = page_size {
         part.page_size = *page_size;
+    }
+    if let Some(isp_iface_num) = isp_iface_num {
+        part.isp_iface_num = *isp_iface_num;
     }
     if let Some(isp_usage_page) = isp_usage_page {
         part.isp_usage_page = *isp_usage_page;

--- a/src/part.rs
+++ b/src/part.rs
@@ -8,6 +8,8 @@ pub struct Part {
     pub vendor_id: u16,
     pub product_id: u16,
 
+    /// USB interface number with the ISP report
+    pub isp_iface_num: u8,
     // The following properties and values are important only for windows support because its
     // HIDAPI requires us to use a specific device for each collection
     /// HID collection `usage_page` with the ISP report
@@ -26,6 +28,7 @@ pub const PART_BASE_DEFAULT: Part = Part {
     vendor_id: 0x0000,
     product_id: 0x0000,
 
+    isp_iface_num: 1,
     isp_usage_page: 0xff00,
     isp_usage: 0x0001,
     isp_index: 0,

--- a/tools/functional-test.sh
+++ b/tools/functional-test.sh
@@ -63,6 +63,7 @@ $TOOL read \
     --product_id 0x024f \
     --bootloader_size 4096 \
     --page_size 2048 \
+    --isp_iface_num 1 \
     --isp_usage_page 0xff00 \
     --isp_usage 0x0001 \
     --isp_index 1 \
@@ -136,6 +137,7 @@ $TOOL write \
     --product_id 0x024f \
     --bootloader_size 4096 \
     --page_size 2048 \
+    --isp_iface_num 1 \
     --isp_usage_page 0xff00 \
     --isp_usage 0x0001 \
     --isp_index 1 \


### PR DESCRIPTION
Addresses the issue encountered in https://github.com/carlossless/sinowealth-kb-tool/issues/28#issuecomment-1880002380 and possibly https://github.com/carlossless/sinowealth-kb-tool/issues/40#issuecomment-1879929586.

I initially thought the selected device per interface would not matter for libusb and that any interface would accept a report that was declared for a different interface, but apparently, it does not. Also, libusb might enumerate these interfaces in varying orders, but that seems purely dependent on the USB descriptor.

Because of this, it's necessary to specify the interface where the ISP report declaration resides. I'm adding in a default (interface_number = 1) and a new argument to customize it. This might unfortunately break the previously declared parts/devices, but from the device reports I saw myself, the ISP report always lives on interface #1, so perhaps there won't be any issues.

Also, just to document this about USBHID somewhere:
* macOS - has exactly the same device paths for each interface (does not matter which interface the report is sent to)
* linux (libusb) - needs a device path with the correct interface for the report
* windows - needs a device path for the specific TLC where thee report was declared in