### PR TITLE
rebooting by the default for all known devices/bootloaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,23 +95,13 @@ sinowealth-kb-tool write \
 
 | ISP MD5                          | Windows  | macOS    | Linux |
 | -------------------------------- | -------- | -------- | ----- |
+| 13df4ce2933f9654ffef80d6a3c27199 | ?        | ?        | ok    |
+| 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
 | 3e0ebd0c440af5236d7ff8872343f85d | ok       | ok       | ok    |
 | cfc8661da8c9d7e351b36c0a763426aa | ok       | fail[^1] | ok    |
-| 2d169670eae0d36eae8188562c1f66e8 | ok       | ?        | ok    |
 | e57490acebcaabfcff84a0ff013955d9 | ok       | ?        | ?     |
-| 13df4ce2933f9654ffef80d6a3c27199 | ?        | ?        | ok    |
 
 [^1]: macOS does not recognize the composite device as an HID device
-
-### Functions
-
-| ISP MD5                          | Reboot |
-| -------------------------------- | ------ |
-| 3e0ebd0c440af5236d7ff8872343f85d | no     |
-| cfc8661da8c9d7e351b36c0a763426aa | yes    |
-| 2d169670eae0d36eae8188562c1f66e8 | ?      |
-| e57490acebcaabfcff84a0ff013955d9 | ?      |
-| 13df4ce2933f9654ffef80d6a3c27199 | ?      |
 
 ## Prerequisites
 

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -1,4 +1,4 @@
-use std::{default, thread, time};
+use std::{thread, time};
 
 use log::{debug, info};
 use thiserror::Error;

--- a/src/isp.rs
+++ b/src/isp.rs
@@ -1,4 +1,4 @@
-use std::{thread, time};
+use std::{default, thread, time};
 
 use log::{debug, info};
 use thiserror::Error;
@@ -452,12 +452,14 @@ impl ISPDevice {
         Ok(())
     }
 
+    /// Causes the device to start running the main firmware
     fn reboot(&self) -> Result<(), ISPError> {
         info!("Rebooting...");
         let cmd: [u8; COMMAND_LENGTH] = [REPORT_ID_CMD, CMD_REBOOT, 0, 0, 0, 0];
-        // explicitly ignore the result
-        let _ = self.request_device.send_feature_report(&cmd);
-
+        if let Err(err) = self.request_device.send_feature_report(&cmd) {
+            // only log failures
+            debug!("Reboot error: {:}", err);
+        }
         thread::sleep(time::Duration::from_millis(2000));
         Ok(())
     }

--- a/src/part.rs
+++ b/src/part.rs
@@ -35,7 +35,7 @@ pub const PART_BASE_DEFAULT: Part = Part {
     isp_usage: 0x0001,
     isp_index: 0,
 
-    reboot: false,
+    reboot: true,
 };
 
 pub const PART_BASE_SH68F90: Part = Part {
@@ -122,28 +122,24 @@ pub const PART_ROYALKLUDGE_RK68_ISO_RETURN: Part = Part {
 pub const PART_ROYALKLUDGE_RK68_BT_DUAL: Part = Part {
     vendor_id: 0x258a,
     product_id: 0x008b,
-    reboot: true,
     ..PART_BASE_SH68F90
 };
 
 pub const PART_ROYALKLUDGE_RK71: Part = Part {
     vendor_id: 0x258a,
     product_id: 0x00ea,
-    reboot: true,
     ..PART_BASE_SH68F90
 };
 
 pub const PART_ROYALKLUDGE_RK84_ISO_RETURN: Part = Part {
     vendor_id: 0x258a,
     product_id: 0x00f4,
-    reboot: true,
     ..PART_BASE_SH68F90
 };
 
 pub const PART_ROYALKLUDGE_RK100: Part = Part {
     vendor_id: 0x258a,
     product_id: 0x0056,
-    reboot: true,
     ..PART_BASE_SH68F90
 };
 


### PR DESCRIPTION
My initial testing `3e0ebd0c440af5236d7ff8872343f85d` seems to have resulted in a false positive and after further testing, it seems that it and all other currently known bootloaders are able to reboot back into main firmware through the same command.