### PR TITLE
Yunzii-al66/Xinmeng-m66

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 /private
 /target
+
+*.hex

--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ sinowealth-kb-tool write \
 | Terport TR95 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
 | Weikav Sugar65 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90S | ✅ | ✅ |
 | Xinmeng K916 | cfc8661da8c9d7e351b36c0a763426aa | SH68F90 | ❓ | ✅ | ✅ |
+| Xinmeng M66 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | SH68F90AS | ✅ | ✅ |
 | Xinmeng M71 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | SH68F90AS | ✅ | ✅ |
 | Xinmeng XM-RF68 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90 | SH68F90U | ✅ | ✅ |
+| Yunzii AL66 | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | SH68F90AS | ✅ | ✅ |
 | Yunzii AL71 | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | SH68F90AS | ✅ | ✅ |
 
 ### Mice

--- a/src/part.rs
+++ b/src/part.rs
@@ -273,8 +273,10 @@ pub static PARTS: Map<&'static str, Part> = phf_map! {
     "trust-gxt-960" => PART_TRUST_GXT_960,
     "weikav-sugar65" => PART_WEIKAV_SUGAR65,
     "xinmeng-k916" => PART_XINMENG_K916,
+    "xinmeng-m66" => PART_XINMENG_M71,
     "xinmeng-m71" => PART_XINMENG_M71,
     "xinmeng-xm-rf68" => PART_XINMENG_XM_RF68,
+    "yunzii-al66" => PART_XINMENG_M71, // same as xinmeng-m71
     "yunzii-al71" => PART_XINMENG_M71, // same as xinmeng-m71
 };
 


### PR DESCRIPTION
I have a yunzii-al66 board, and it is (I think) internally the same as the yunzii-al71, but with 5 fewer keys. The `vendor_id` and `product_id` are the same as the yunzi-al71. It follows that it's probably also the same as the xinmeng-m66 (but i dont own this board). Writing also seemed to work.