### PR TITLE
add Redragon K630 Single Color version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ sinowealth-kb-tool write \
 | [NuPhy Halo65](https://nuphy.com/products/halo65) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [Portronics Hydra 10](https://www.portronics.com/products/hydra-10) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
 | [Redragon K530 Draconic PRO](https://www.redragonzone.com/products/draconic-k530) | cfc8661da8c9d7e351b36c0a763426aa | SH68F90A | BYK916 | ✅ | ✅ |
+| [Redragon K630 Single LED version](https://www.redragonzone.com/products/redragon-k630-gaming-mechanical-keyboard) | cfc8661da8c9d7e351b36c0a763426aa | SH68F90A | SH68F90AU | ✅ | ✅ |
 | [Redragon K614 Anivia 60%](https://www.redragonzone.com/products/redragon-k614-anivia-60-ultra-thin-wired-mechanical-keyboard) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
 | [Redragon K617 FIZZ 60%](https://www.redragonzone.com/collections/keyboard/products/redragon-k617-fizz-60-wired-rgb-gaming-keyboard-61-keys-compact-mechanical-keyboard) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |
 | [Redragon K633 RYZE](https://www.redragonzone.com/products/redragon-k633-ryze-rgb-led-backlit-mechanical-gaming-keyboard-with-68-professional-keys-linear-red-switches) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90A | BYK916 | ✅ | ✅ |

--- a/src/part.rs
+++ b/src/part.rs
@@ -235,6 +235,12 @@ pub const PART_REDRAGON_K530_DRACONIC_PRO: Part = Part {
     ..PART_BASE_SH68F90
 };
 
+pub const PART_REDRAGON_K630_NO_RGB: Part = Part {
+    vendor_id: 0x258a,
+    product_id: 0x002a,
+    ..PART_BASE_SH68F90
+};
+
 pub const PART_EYOOSO_Z11: Part = Part {
     vendor_id: 0x258a,
     product_id: 0x002a,
@@ -271,6 +277,7 @@ pub static PARTS: Map<&'static str, Part> = phf_map! {
     "portronics-hydra10" => PART_PORTRONICS_HYDRA10,
     "re-k70-byk800" => PART_RE_K70_BYK800,
     "redragon-k530-draconic-pro" => PART_REDRAGON_K530_DRACONIC_PRO,
+    "redragon-k630-norgb" => PART_REDRAGON_K630_NO_RGB,
     "redragon-k614-anivia" => PART_REDRAGON_ANIVIA_K614,
     "redragon-k617-fizz" => PART_REDRAGON_FIZZ_K617,
     "redragon-k633-ryze" => PART_REDRAGON_K633_RYZE,


### PR DESCRIPTION
Add support for Redragon K630 non-rgb version.

It's basically the same as the E-Yooso Z11.

Tested Reading and Writing both works.