### PR TITLE
Rename package to sinowisp

### DIFF
--- a/.github/ISSUE_TEMPLATE/device-report.md
+++ b/.github/ISSUE_TEMPLATE/device-report.md
@@ -41,17 +41,17 @@ reboot: false # necessary if not default, otherwise remove this line
 ## Checksums
 
 - Stock Firmware MD5: `deadbeefdeadbeefdeadbeefdeadbeef`
-- Bootloader MD5: `beefcafebeefcafebeefcafebeefcafe` _(shown when running `sinowealth-kb-tool read -s bootloader ...`)_
+- Bootloader MD5: `beefcafebeefcafebeefcafebeefcafe` _(shown when running `sinowisp read -s bootloader ...`)_
 
 ## Device Info (HID Reports)
 
-Output when running `sinowealth-kb-tool list --vendor_id=<PID> --product_id=<PID>`
+Output when running `sinowisp list --vendor_id=<PID> --product_id=<PID>`
 
 <details>
 <summary>Output</summary>
 
 ```
-sinowealth-kb-tool list --vendor_id=0x05ac --product_id=0x024f
+sinowisp list --vendor_id=0x05ac --product_id=0x024f
 ID 05ac:024f manufacturer="contact@carlossless.io" product="SMK Keyboard"
     path="DevSrvsID:4294974930" interface_number=0
     report_descriptor=[05 01 09 06 A1 01 05 07 19 E0 29 E7 15 00 25 01 75 01 95 08 81 02 75 08 95 01 81 01 05 07 19 00 29 FF 15 00 26 FF 00 75 08 95 06 81 00 05 08 19 01 29 05 15 00 25 01 75 01 95 05 91 02 75 03 95 01 91 01 C0]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,8 @@ jobs:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: cachix/cachix-action@v14
       with:
-        name: sinowisp
+        # TODO: rename to `sinowisp` once the Cachix cache is renamed/created
+        name: sinowealth-kb-tool
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
     - name: Build
       run: nix build

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: cachix/cachix-action@v14
       with:
-        name: sinowealth-kb-tool
+        name: sinowisp
         authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
     - name: Build
       run: nix build
@@ -75,7 +75,7 @@ jobs:
     needs: test
     runs-on: ${{ matrix.OS }}
     env:
-      NAME: sinowealth-kb-tool
+      NAME: sinowisp
       TARGET: ${{ matrix.TARGET }}
       OS: ${{ matrix.OS }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,7 +927,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "sinowealth-kb-tool"
+name = "sinowisp"
 version = "1.0.1"
 dependencies = [
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "sinowealth-kb-tool"
+name = "sinowisp"
 description = """
 A utility for reading and writing flash contents on Sinowealth 8051-based HID devices through the commonly found ISP bootloader
 """
-repository = "https://github.com/carlossless/sinowealth-kb-tool"
+repository = "https://github.com/carlossless/sinowisp"
 version = "1.0.1"
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# sinowealth-kb-tool
+# sinowisp
 
-[![crate](https://img.shields.io/crates/v/sinowealth-kb-tool.svg)](https://crates.io/crates/sinowealth-kb-tool) [![ci](https://github.com/carlossless/sinowealth-kb-tool/actions/workflows/push.yml/badge.svg)](https://github.com/carlossless/sinowealth-kb-tool/actions/workflows/push.yml)
+[![crate](https://img.shields.io/crates/v/sinowisp.svg)](https://crates.io/crates/sinowisp) [![ci](https://github.com/carlossless/sinowisp/actions/workflows/push.yml/badge.svg)](https://github.com/carlossless/sinowisp/actions/workflows/push.yml)
 
 A utility for reading and writing flash contents on Sinowealth 8051-based USB HID devices (keyboards and mice) through the commonly found ISP bootloader.
 
@@ -18,16 +18,16 @@ I offer no guarantees that using this tool won't brick your device. Use this too
 
 ```sh
 # reads firmware excluding isp bootloader 
-sinowealth-kb-tool read -d nuphy-air60 foobar.hex
+sinowisp read -d nuphy-air60 foobar.hex
 
 # reads only isp bootloader section
-sinowealth-kb-tool read -d nuphy-air60 -s bootloader bootloader.hex
+sinowisp read -d nuphy-air60 -s bootloader bootloader.hex
 
 # full dump including firmware and bootloader
-sinowealth-kb-tool read -d nuphy-air60 -s full full.hex
+sinowisp read -d nuphy-air60 -s full full.hex
 
 # custom device
-sinowealth-kb-tool read \
+sinowisp read \
     --platform sh68f90 \
     --vendor_id 0x05ac \
     --product_id 0x024f \
@@ -46,10 +46,10 @@ sinowealth-kb-tool read \
 
 ```sh
 # overwrites firmware (does not touch the bootloader section)
-sinowealth-kb-tool write -p nuphy-air60 foobar.hex
+sinowisp write -p nuphy-air60 foobar.hex
 
 # custom device
-sinowealth-kb-tool write \
+sinowisp write \
     --platform sh68f90 \
     --vendor_id 0x05ac \
     --product_id 0x024f \

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
         packages = {
           # For `nix build` `nix run`, & `nix profile install`:
           default = naersk'.buildPackage {
-            pname = "sinowealth-kb-tool";
+            pname = "sinowisp";
             version = "latest";
 
             src = ./.;
@@ -54,9 +54,9 @@
 
             meta = with pkgs.lib; {
               description = "A utility for reading and writing flash contents on Sinowealth 8051-based devices";
-              homepage = "https://github.com/carlossless/sinowealth-kb-tool";
+              homepage = "https://github.com/carlossless/sinowisp";
               license = licenses.mit;
-              mainProgram = "sinowealth-kb-tool";
+              mainProgram = "sinowisp";
               maintainers = with maintainers; [ carlossless ];
             };
           };

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> ExitCode {
 }
 
 fn cli() -> Command {
-    Command::new("sinowealth-kb-tool")
+    Command::new("sinowisp")
         .about("A tool to read and write flash for SinoWealth ISP devices")
         .version(env!("CARGO_PKG_VERSION"))
         .subcommand_required(true)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,7 @@ macro_rules! test_filename {
         let date = chrono::Utc::now().to_rfc3339().replace(":", "-");
         let mut path = std::env::temp_dir();
         path.push(format!(
-            "sinowealth-kb-tool-{}-{}.{}",
+            "sinowisp-{}-{}.{}",
             date,
             stdext::function_name!()
                 .replace(":", "_")

--- a/tests/convert_test.rs
+++ b/tests/convert_test.rs
@@ -13,7 +13,7 @@ use common::get_fixture_path;
 fn test_convert_to_jtag() {
     let input_file = get_fixture_path("nuphy-air60_smk.hex");
     let output_file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("convert")
         .args(&["--device", "nuphy-air60"])
@@ -36,7 +36,7 @@ fn test_convert_to_jtag() {
 fn test_convert_to_isp() {
     let input_file = get_fixture_path("nuphy-air60_smk_jtag.hex");
     let output_file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("convert")
         .args(&["--device", "nuphy-air60"])
@@ -59,7 +59,7 @@ fn test_convert_to_isp() {
 fn test_convert_to_jtag_bin() {
     let input_file = get_fixture_path("nuphy-air60_smk.hex");
     let output_file = test_filename!("bin");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("convert")
         .args(&["--device", "nuphy-air60"])

--- a/tests/list_test.rs
+++ b/tests/list_test.rs
@@ -56,7 +56,7 @@ ID 05ac:024f manufacturer=\"contact@carlossless.io\" product=\"SMK Keyboard\"
 #[test]
 #[serial]
 fn test_list_devices() {
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd.arg("list").assert();
     assert
         .success()
@@ -66,7 +66,7 @@ fn test_list_devices() {
 #[test]
 #[serial]
 fn test_list_with_vid_filter() {
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd.arg("list").args(&["--vendor_id", "0x05ac"]).assert();
     assert
         .success()
@@ -76,7 +76,7 @@ fn test_list_with_vid_filter() {
 #[test]
 #[serial]
 fn test_list_with_pid_filter() {
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd.arg("list").args(&["--product_id", "0x024f"]).assert();
     assert
         .success()
@@ -86,7 +86,7 @@ fn test_list_with_pid_filter() {
 #[test]
 #[serial]
 fn test_list_with_vid_and_pid_filter() {
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("list")
         .args(&["--vendor_id", "0x05ac"])

--- a/tests/read_test.rs
+++ b/tests/read_test.rs
@@ -10,7 +10,7 @@ pub mod common;
 #[serial]
 fn test_read() {
     let file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("read")
         .args(&["--device", "nuphy-air60"])
@@ -31,7 +31,7 @@ fn test_read() {
 #[serial]
 fn test_read_bin() {
     let file = test_filename!("bin");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("read")
         .args(&["--device", "nuphy-air60"])
@@ -52,7 +52,7 @@ fn test_read_bin() {
 #[serial]
 fn test_read_bootloader() {
     let file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("read")
         .args(&["--device", "nuphy-air60"])
@@ -74,7 +74,7 @@ fn test_read_bootloader() {
 #[serial]
 fn test_read_full() {
     let file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("read")
         .args(&["--device", "nuphy-air60"])
@@ -96,7 +96,7 @@ fn test_read_full() {
 #[serial]
 fn test_read_custom_part() {
     let file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("read")
         .args(&["--platform", "sh68f90"])
@@ -122,7 +122,7 @@ fn test_read_custom_part() {
 #[serial]
 fn test_read_forced_format_bin() {
     let file = test_filename!("hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("read")
         .args(&["--device", "nuphy-air60"])

--- a/tests/write_test.rs
+++ b/tests/write_test.rs
@@ -12,7 +12,7 @@ use common::get_fixture_path;
 #[serial]
 fn test_write() {
     let file = get_fixture_path("nuphy-air60_smk.hex");
-    let mut cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = cmd
         .arg("write")
         .args(&["--device", "nuphy-air60"])
@@ -25,7 +25,7 @@ fn test_write() {
 #[serial]
 fn test_write_and_readback() {
     let fixture_file = get_fixture_path("nuphy-air60_smk.hex");
-    let mut write_cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut write_cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = write_cmd
         .arg("write")
         .args(&["--device", "nuphy-air60"])
@@ -34,7 +34,7 @@ fn test_write_and_readback() {
     assert.success();
 
     let output_file = test_filename!("hex");
-    let mut read_cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut read_cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = read_cmd
         .arg("read")
         .args(&["--device", "nuphy-air60"])
@@ -55,7 +55,7 @@ fn test_write_and_readback() {
 #[serial]
 fn test_write_custom_and_readback() {
     let fixture_file = get_fixture_path("nuphy-air60_smk.hex");
-    let mut write_cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut write_cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = write_cmd
         .arg("write")
         .args(&["--platform", "sh68f90"])
@@ -69,7 +69,7 @@ fn test_write_custom_and_readback() {
     assert.success();
 
     let output_file = test_filename!("hex");
-    let mut read_cmd = Command::cargo_bin("sinowealth-kb-tool").unwrap();
+    let mut read_cmd = Command::cargo_bin("sinowisp").unwrap();
     let assert = read_cmd
         .arg("read")
         .args(&["--platform", "sh68f90"])


### PR DESCRIPTION
Renames the crate, binary, and every `sinowealth-kb-tool` tool-name reference to `sinowisp`, in preparation for renaming the GitHub repository and Cargo package.

## Scope
- `Cargo.toml` / `Cargo.lock`: package name (also updates the `repository` URL to the future `carlossless/sinowisp`)
- `src/main.rs`: CLI command name
- `flake.nix`: `pname`, `mainProgram`, `homepage`
- `.github/workflows/push.yml`: build artifact `NAME` and cachix cache `name`
- `README.md` + issue template: title, badges, usage examples
- `tests/`: `cargo_bin` targets and temp-file prefix

Vendor references to the **Sinowealth** chip family (in descriptions) are intentionally left unchanged — they name the hardware, not the tool.

## Follow-ups needed on the service side (not doable in this PR)
- Rename the GitHub repo `carlossless/sinowealth-kb-tool` → `carlossless/sinowisp` (makes the updated badge/URL links resolve)
- Create/rename the Cachix cache to `sinowisp` so the `nix-build` job's cache push succeeds
- Publish/rename the crates.io package

https://claude.ai/code/session_01MiFqdrz3fGWL2Ue6N8rka2