### PR TITLE
docs: note former name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sinowisp
 
+_(formerly `sinowealth-kb-tool`)_
+
 [![crate](https://img.shields.io/crates/v/sinowisp.svg)](https://crates.io/crates/sinowisp) [![ci](https://github.com/carlossless/sinowisp/actions/workflows/push.yml/badge.svg)](https://github.com/carlossless/sinowisp/actions/workflows/push.yml)
 
 A utility for reading and writing flash contents on Sinowealth 8051-based USB HID devices (keyboards and mice) through the commonly found ISP bootloader.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # sinowisp
 
-_(formerly `sinowealth-kb-tool`)_
-
 [![crate](https://img.shields.io/crates/v/sinowisp.svg)](https://crates.io/crates/sinowisp) [![ci](https://github.com/carlossless/sinowisp/actions/workflows/push.yml/badge.svg)](https://github.com/carlossless/sinowisp/actions/workflows/push.yml)
+
+_(formerly `sinowealth-kb-tool`)_
 
 A utility for reading and writing flash contents on Sinowealth 8051-based USB HID devices (keyboards and mice) through the commonly found ISP bootloader.
 


### PR DESCRIPTION
Adds a small note under the title indicating the project's former name, for anyone arriving from the old `sinowealth-kb-tool` name.

```
# sinowisp

_(formerly `sinowealth-kb-tool`)_
```

https://claude.ai/code/session_01MiFqdrz3fGWL2Ue6N8rka2