### PR TITLE
Auto-select the nusb backend on Linux

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,10 +56,8 @@ jobs:
             ~/.cargo/registry
             ./target
           key: test-cargo-registry
-      - name: Run tests (hidraw backend)
+      - name: Run tests
         run: cargo test --workspace --lib --bins --verbose
-      - name: Run tests (nusb backend)
-        run: cargo test --workspace --lib --bins --features nusb --verbose
 
   wasm:
     runs-on: ubuntu-latest
@@ -84,31 +82,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Two Linux variants: the default hidraw backend and the nusb backend.
+          # Linux always uses hidra's nusb backend (auto-selected in Cargo.toml).
           - TARGET: x86_64-unknown-linux-gnu
             OS: ubuntu-latest
-            FEATURES: ""
-            LABEL: hidraw
-          - TARGET: x86_64-unknown-linux-gnu
-            OS: ubuntu-latest
-            FEATURES: "nusb"
-            LABEL: nusb
           - TARGET: x86_64-apple-darwin
             OS: macos-latest
-            FEATURES: ""
-            LABEL: ""
           - TARGET: x86_64-pc-windows-msvc
             OS: windows-latest
-            FEATURES: ""
-            LABEL: ""
     needs: test
     runs-on: ${{ matrix.OS }}
     env:
       NAME: sinowisp
       TARGET: ${{ matrix.TARGET }}
       OS: ${{ matrix.OS }}
-      FEATURES: ${{ matrix.FEATURES }}
-      LABEL: ${{ matrix.LABEL }}
     steps:
       - uses: actions/checkout@v6
       - name: Cargo cache
@@ -117,11 +103,11 @@ jobs:
           path: |
             ~/.cargo/registry
             ./target
-          key: build-cargo-registry-${{matrix.TARGET}}-${{matrix.LABEL}}
+          key: build-cargo-registry-${{matrix.TARGET}}
       - name: Install rust target
         run: rustup target add $TARGET
       - name: Run build
-        run: cargo build --release --verbose --target $TARGET ${FEATURES:+--features "$FEATURES"}
+        run: cargo build --release --verbose --target $TARGET
       - name: Compress
         run: |
           mkdir -p ./artifacts
@@ -136,14 +122,13 @@ jobs:
           else
             TAG=$GITHUB_SHA
           fi
-          # include the backend label in the artifact name when set (Linux)
-          ARTIFACT=$NAME-$TARGET${LABEL:+-$LABEL}-$TAG
+          ARTIFACT=$NAME-$TARGET-$TAG
           mv ./target/$TARGET/release/$EXEC ./$EXEC
           tar -czf ./artifacts/$ARTIFACT.tar.gz $EXEC
       - name: Archive artifact
         uses: actions/upload-artifact@v7
         with:
-          name: result-${{ matrix.TARGET }}${{ matrix.LABEL && format('-{0}', matrix.LABEL) || '' }}
+          name: result-${{ matrix.TARGET }}
           path: |
             ./artifacts
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,8 +346,7 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 [[package]]
 name = "hidra"
 version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d836e89bf600a7cf879b55ac9db1169ec1584848e1640002b9389107d1768b"
+source = "git+https://github.com/carlossless/hidra.git?branch=master#4fca641c921fd825c48953c4835a21a2e62a6993"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,8 +345,9 @@ checksum = "efb8ae90b8d0165be79ff98d845bebbbc9dfa0295ff2ce86beba525d93b9ba60"
 
 [[package]]
 name = "hidra"
-version = "0.0.1"
-source = "git+https://github.com/carlossless/hidra.git?branch=master#4fca641c921fd825c48953c4835a21a2e62a6993"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1a3e082dff027a9cf7c50357d65e8afbfd6f6592ae23990ac789d9b2153e78"
 dependencies = [
  "core-foundation-sys",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ cli = [
     "dep:log",
 ]
 # Switch hidra to its nusb-based USB backend instead of the per-OS native one.
+# Linux always uses nusb (auto-selected via the target-specific dependency
+# below); this feature exists to opt into nusb on macOS/Windows as well.
 nusb = ["hidra/nusb"]
 
 [[bin]]
@@ -35,9 +37,9 @@ path = "src/main.rs"
 required-features = ["cli"]
 
 [dependencies]
-# Pure-Rust HID. On Linux the default is the hidraw backend; the `nusb`
-# feature switches to the nusb-based backend (the hidapi `linux-static-libusb`
-# equivalent).
+# Pure-Rust HID. On macOS/Windows this uses hidra's native per-OS backend; on
+# Linux the nusb backend is auto-selected via the target-specific dependency
+# below (the hidapi `linux-static-libusb` equivalent). wasm uses WebHID.
 hidra = "0.0.1"
 ihex = "3.0"
 thiserror = "2.0"
@@ -58,6 +60,11 @@ version = "5.1"
 default-features = false
 features = ["stderr", "colors", "timestamps"]
 optional = true
+
+# On Linux there is no native hidraw path we want; always use hidra's nusb
+# backend. Cargo features are additive, so this is unconditional on Linux.
+[target.'cfg(target_os = "linux")'.dependencies]
+hidra = { version = "0.0.1", features = ["nusb"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,10 @@ chrono = "0.4.41"
 predicates = "3.1.3"
 serial_test = "3.2.0"
 stdext = "0.3.3"
+
+# TEMPORARY: pull hidra from git master until the macOS run-loop fix (the
+# false `HidError::Disconnected` on ISP re-enumeration) ships to crates.io.
+# Both `hidra` requirements above resolve through this source (master is
+# still 0.0.1). Revert to the published crate before releasing.
+[patch.crates-io]
+hidra = { git = "https://github.com/carlossless/hidra.git", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ required-features = ["cli"]
 # Pure-Rust HID. On macOS/Windows this uses hidra's native per-OS backend; on
 # Linux the nusb backend is auto-selected via the target-specific dependency
 # below (the hidapi `linux-static-libusb` equivalent). wasm uses WebHID.
-hidra = "0.0.1"
+hidra = "0.0.2"
 ihex = "3.0"
 thiserror = "2.0"
 phf = { version = "0.11", features = ["macros"] }
@@ -64,7 +64,7 @@ optional = true
 # On Linux there is no native hidraw path we want; always use hidra's nusb
 # backend. Cargo features are additive, so this is unconditional on Linux.
 [target.'cfg(target_os = "linux")'.dependencies]
-hidra = { version = "0.0.1", features = ["nusb"] }
+hidra = { version = "0.0.2", features = ["nusb"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.17"
@@ -72,10 +72,3 @@ chrono = "0.4.41"
 predicates = "3.1.3"
 serial_test = "3.2.0"
 stdext = "0.3.3"
-
-# TEMPORARY: pull hidra from git master until the macOS run-loop fix (the
-# false `HidError::Disconnected` on ISP re-enumeration) ships to crates.io.
-# Both `hidra` requirements above resolve through this source (master is
-# still 0.0.1). Revert to the published crate before releasing.
-[patch.crates-io]
-hidra = { git = "https://github.com/carlossless/hidra.git", branch = "master" }


### PR DESCRIPTION
## What

Linux builds now use hidra's **nusb** backend automatically — no `--features nusb` needed. A target-specific dependency enables `hidra/nusb` under `cfg(target_os = "linux")`, so a plain `cargo build` on Linux pulls it in.

```toml
[target.'cfg(target_os = "linux")'.dependencies]
hidra = { version = "0.0.1", features = ["nusb"] }
```

macOS/Windows keep hidra's native per-OS backend; wasm keeps WebHID. The `nusb` feature is retained for opting into nusb on macOS/Windows.

## Trade-off

Cargo features are additive, so this makes nusb the **sole** Linux backend — the hidraw variant is no longer buildable on Linux. That's intentional.

## CI

With the Linux backend split gone, the build/test matrix collapses to a single Linux variant and the now-unused `FEATURES`/`LABEL` plumbing (env vars, cache-key suffix, `--features` injection, artifact-name label) is removed. The Linux artifact is now `sinowisp-x86_64-unknown-linux-gnu-<tag>.tar.gz`, matching macOS/Windows.