### PR TITLE
device: leobog-hi75c-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ sinowisp write \
 | Hykker X Range 2017 (RE-K70-BYK800) | 13df4ce2933f9654ffef80d6a3c27199 | SH68F881 | BYK801 | ✅ | ❓ |
 | [Kzzi K68Pro](http://en.kzzi.com/product/37/) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | ❓ | ✅ | ✅ |
 | [Leobog Hi75](https://leobogtech.com/products/leobog-hi75) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
+| Leobog Hi75c Pro | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [Machenike K500-B61](https://global.machenike.com/products/k500-b61) | 2d169670eae0d36eae8188562c1f66e8 | SH68F90? | BYK916 | ✅ | ✅ |
 | [MageGee MK-STAR61](https://www.magegee.com/products2.html?pid=1644595&_t=1737191677) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |
 | [NuPhy Air60](https://nuphy.com/products/air60) | 3e0ebd0c440af5236d7ff8872343f85d | SH68F90A | BYK916 | ✅ | ✅ |

--- a/src/device_spec.rs
+++ b/src/device_spec.rs
@@ -124,6 +124,12 @@ pub const DEVICE_LEOBOG_HI75: DeviceSpec = DeviceSpec {
     ..DEVICE_BASE_SH68F90
 };
 
+pub const DEVICE_LEOBOG_HI75C_PRO: DeviceSpec = DeviceSpec {
+    vendor_id: 0x258a,
+    product_id: 0x010c,
+    ..DEVICE_BASE_SH68F90
+};
+
 pub const DEVICE_MACHENIKE_K500_B61: DeviceSpec = DeviceSpec {
     vendor_id: 0x258a,
     product_id: 0x0049,
@@ -313,6 +319,7 @@ pub static DEVICES: Map<&'static str, DeviceSpec> = phf_map! {
     "glorious-model-o" => DEVICE_GLORIOUS_MODEL_O,
     "kzzi-k68pro" => DEVICE_KZZI_K68PRO,
     "leobog-hi75" => DEVICE_LEOBOG_HI75,
+    "leobog-hi75c-pro" => DEVICE_LEOBOG_HI75C_PRO,
     "machenike-k500-b61" => DEVICE_MACHENIKE_K500_B61,
     "magegee-mkstar61" => DEVICE_MAGEGEE_MKSTAR61,
     "nuphy-air60" => DEVICE_NUPHY_AIR60,


### PR DESCRIPTION
Adds the Leobog Hi75c Pro keyboard. Closes #130.